### PR TITLE
Clearer mistletoe message

### DIFF
--- a/execnb/shell.py
+++ b/execnb/shell.py
@@ -165,7 +165,7 @@ def render_outputs(outputs, ansi_renderer=_strip, include_imgs=True, pygments=Fa
     try:
         from mistletoe import markdown, HTMLRenderer
         from mistletoe.contrib.pygments_renderer import PygmentsRenderer
-    except ImportError: return print('mistletoe not found -- please install it')
+    except ImportError: return print('mistletoe not found -- please install it for execnb.shell.render_output')
     renderer = PygmentsRenderer if pygments else HTMLRenderer
     def render_output(out):
         otype = out['output_type']

--- a/nbs/02_shell.ipynb
+++ b/nbs/02_shell.ipynb
@@ -981,7 +981,7 @@
     "    try:\n",
     "        from mistletoe import markdown, HTMLRenderer\n",
     "        from mistletoe.contrib.pygments_renderer import PygmentsRenderer\n",
-    "    except ImportError: return print('mistletoe not found -- please install it')\n",
+    "    except ImportError: return print('mistletoe not found -- please install it for execnb.shell.render_output')\n",
     "    renderer = PygmentsRenderer if pygments else HTMLRenderer\n",
     "    def render_output(out):\n",
     "        otype = out['output_type']\n",


### PR DESCRIPTION
## Background 

If mistletoe isn't installed, then the error is captured while a text string is returned and sent to logs. There is no option to use other renders. This makes mistletoe a 'magic dependency'.

## What this PR does

The change is intentionally tiny. It just changes the log message to be explicitly that it is about this package. That makes identifying the cause of failure in production much more straightforward. 